### PR TITLE
Test that export ∘ import = id (just atom, for now)

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -101,6 +101,7 @@ test-suite tests
     Paths_feed
     Example
     Example.CreateAtom
+    ImportExport
     Text.Atom.Tests
     Text.Feed.Util.Tests
     Text.RSS.Equals
@@ -114,6 +115,7 @@ test-suite tests
     , HUnit >= 1.2 && < 1.7
     , feed
     , old-time >= 1 && < 1.2
+    , syb
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*
     , text < 1.3

--- a/tests/ImportExport.hs
+++ b/tests/ImportExport.hs
@@ -1,0 +1,46 @@
+module ImportExport
+  ( importExportTests
+  ) where
+
+import Prelude.Compat
+
+import Data.Generics (everywhere, mkT)
+import Data.Text (strip)
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@=?))
+import qualified Data.Text.Lazy.IO as T
+import qualified Data.XML.Types as XML
+import qualified Text.XML as C
+
+import Text.Feed.Export (xmlFeed)
+import Text.Feed.Import (readAtom)
+import Text.Feed.Types (Feed)
+import Text.RSS.Utils (elementToDoc)
+
+import Paths_feed
+
+importExportTests :: Test
+importExportTests = testGroup "ImportExport"
+  [ testImportExport readAtom "tests/files/import_export_atom.xml"
+  ]
+
+testImportExport :: (XML.Element -> Maybe Feed) -> FilePath -> Test
+testImportExport readFeed fileName = testCase fileName $ do
+  input <- T.readFile =<< getDataFileName fileName
+  let inputXml = C.parseText_ C.def input
+  let Just feed = readFeed $ C.toXMLElement $ C.documentRoot inputXml
+  let Just outputXml = elementToDoc $ xmlFeed feed
+  let output = C.renderText C.def outputXml
+  let input' = C.renderText C.def $ stripXmlWhitespace inputXml
+  input' @=? output
+
+stripXmlWhitespace :: C.Document -> C.Document
+stripXmlWhitespace = everywhere (mkT stripWhitespaceNodes)
+  where
+    stripWhitespaceNodes e =
+      e { C.elementNodes = filter (not . isWhite) (C.elementNodes e) }
+
+    isWhite (C.NodeContent t) = strip t == ""
+    isWhite (C.NodeComment _) = True
+    isWhite _ = False

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,10 +5,11 @@ module Main
 import Prelude.Compat
 
 import Example (exampleTests)
+import ImportExport (importExportTests)
 import Test.Framework (defaultMain)
 import Text.Atom.Tests (atomTests)
 import Text.Feed.Util.Tests (feedUtilTests)
 import Text.RSS.Tests (rssTests)
 
 main :: IO ()
-main = defaultMain [rssTests, atomTests, feedUtilTests, exampleTests]
+main = defaultMain [rssTests, atomTests, feedUtilTests, exampleTests, importExportTests]

--- a/tests/files/import_export_atom.xml
+++ b/tests/files/import_export_atom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">Example Feed</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <link href="http://example.org/feed/" rel="self"/>
+  <link href="http://example.org/"/>
+  <subtitle type="text">A subtitle.</subtitle>
+  <entry>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <title type="text">Atom-Powered Robots Run Amok</title>
+    <updated>2003-12-13T18:30:00Z</updated>
+    <author>
+      <name>John Doe</name>
+      <email>johndoe@example.com</email>
+    </author>
+    <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>This is the entry content.</p></div></content>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <link href="http://example.org/2003/12/13/atom03.html" rel="alternate" type="text/html"/>
+    <link href="http://example.org/2003/12/13/atom03/edit" rel="edit"/>
+    <summary type="html">&lt;div&gt;&lt;p&gt;This is the entry content.&lt;/p&gt;&lt;/div&gt;</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
This is meant to ensure that a standards-compliant atom feed can be
imported without losing information (see 143c161e2d) and exported
without introducing weird reader-confusing glitches (see 7bd18d381c).